### PR TITLE
[TASK] Replace Swift Mailer with Symfony Mailer

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,8 @@
     ],
     "require": {
         "php": "^7.2",
-        "form-relay/core": "^2.0"
+        "form-relay/core": "^2.0",
+        "symfony/mailer": "^5.3.4"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8.35 || ^5.7 || ^6.4 || ^7.0"

--- a/src/Manager/DefaultMailManager.php
+++ b/src/Manager/DefaultMailManager.php
@@ -2,11 +2,10 @@
 
 namespace FormRelay\Mail\Manager;
 
-use Swift_Mailer;
-use Swift_Message;
-use Swift_SendmailTransport;
-use Swift_SmtpTransport;
-use Swift_Transport;
+use Symfony\Component\Mailer\Transport;
+use Symfony\Component\Mailer\Transport\SendmailTransport;
+use Symfony\Component\Mailer\Transport\Smtp\SmtpTransport;
+use Symfony\Component\Mime\Email;
 
 class DefaultMailManager implements MailManagerInterface
 {
@@ -38,16 +37,16 @@ class DefaultMailManager implements MailManagerInterface
         $this->transportConfiguration = $transportConfiguration;
     }
 
-    public function getTransport(): Swift_Transport
+    public function getTransport(): Transport
     {
         $transport = null;
         $config = $this->transportConfiguration[static::TRANSPORT_CONFIG];
         switch ($this->transportConfiguration[static::TRANSPORT_TYPE]) {
             case static::TRANSPORT_TYPE_SENDMAIL:
-                $transport = new Swift_SendmailTransport($config[static::TRANSPORT_CONFIG_SENDMAIL_CMD]);
+                $transport = new SendmailTransport($config[static::TRANSPORT_CONFIG_SENDMAIL_CMD]);
                 break;
             case static::TRANSPORT_TYPE_SMTP:
-                $transport = new Swift_SmtpTransport(
+                $transport = new SmtpTransport(
                     $config[static::TRANSPORT_CONFIG_SMTP_DOMAIN],
                     $config[static::TRANSPORT_CONFIG_SMTP_PORT]
                 );
@@ -62,21 +61,21 @@ class DefaultMailManager implements MailManagerInterface
         return $transport;
     }
 
-    public function getMailer(): Swift_Mailer
+    public function getMailer(): Email
     {
         $transport = $this->getTransport();
-        return new Swift_Mailer($transport);
+        return new Email($transport);
     }
 
-    public function createMessage(): Swift_Message
+    public function createMessage(): Email
     {
         $mailer = $this->getMailer();
-        /** @var Swift_Message $message */
+        /** @var Email $message */
         $message = $mailer->createMessage();
         return $message;
     }
 
-    public function sendMessage(Swift_Message $message): bool
+    public function sendMessage(Email $message): bool
     {
         return (bool)$this->getMailer()->send($message);
     }

--- a/src/Manager/MailManagerInterface.php
+++ b/src/Manager/MailManagerInterface.php
@@ -2,10 +2,10 @@
 
 namespace FormRelay\Mail\Manager;
 
-use Swift_Message;
+use Symfony\Component\Mime\Email;
 
 interface MailManagerInterface
 {
-    public function createMessage(): Swift_Message;
-    public function sendMessage(Swift_Message $message): bool;
+    public function createMessage(): Email;
+    public function sendMessage(Email $message): bool;
 }


### PR DESCRIPTION
- Replace Swift Mailer, which was dropped from the TYPO3 core
- Declare TYPO3 11 compatibility
- Drop TYPO3 9.5 compatibility